### PR TITLE
fixed the float<->int conversion error

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -250,7 +250,7 @@ class EVERTimsSetObject(Operator):
         if not integerList:
             return 1
         else:
-            for i in range(max(integerList)+1):
+            for i in range(int(max(integerList))+1):
                 index = i + 1
                 if index not in integerList:
                     newVal = index


### PR DESCRIPTION
I am using the latest Blender version 2.78 and this error pops up. I edited the operator.py file to enforce a explicit type conversion. The updated script runs without error.

![snip20170502_1](https://cloud.githubusercontent.com/assets/5297902/25633425/04a01192-2f45-11e7-9e9a-89c2d82277c0.png)
